### PR TITLE
Fix Unexpected data found

### DIFF
--- a/src/ViewDirectives/BannersDirective.php
+++ b/src/ViewDirectives/BannersDirective.php
@@ -63,6 +63,6 @@ class BannersDirective
         $from = Carbon::createFromFormat('Y-m-d H:i:s', $banner->from_date, $timezone);
         $to = Carbon::createFromFormat('Y-m-d H:i:s', $banner->to_date, $timezone);
 
-        return Carbon::createFromFormat('Y-m-d H:i:s', Carbon::now()->setTimezone($timezone), $timezone)->between($from, $to);
+        return Carbon::now()->setTimezone($timezone)->between($from, $to);
     }
 }


### PR DESCRIPTION
createFromFormat expects a string matching the format
we pass a carbon instance
This causes 
> Unexpected data found. Unexpected data found. The separation symbol could not be found Not enough data available to satisfy format

However we already have a carbon instance in the correct timezone, so we don't need to do this.